### PR TITLE
:tada: Rest version has options

### DIFF
--- a/src/clients/SquidClient.ts
+++ b/src/clients/SquidClient.ts
@@ -18,12 +18,14 @@ class SquidClient implements AbstractClient<SquidCollection, SquidNFT> {
 
   collectionListByIssuer(issuer: string, options?: QueryProps<SquidCollection>): GraphQuery {
     const toQuery = getFields(options?.fields)
-    return build(`collections: collectionEntities(where: {issuer_eq: "${issuer}"})`, toQuery)
+    const optionList = optionToQuery(options, true)
+    return build(`collections: collectionEntities(where: {issuer_eq: "${issuer}"} ${optionList})`, toQuery)
   }
 
   collectionListByOwner(owner: string, options?: QueryProps<SquidCollection>): GraphQuery {
     const toQuery = getFields(options?.fields)
-    return build(`collections: collectionEntities(where: {currentOwner_eq: "${owner}"})`, toQuery)
+    const optionList = optionToQuery(options, true)
+    return build(`collections: collectionEntities(where: {currentOwner_eq: "${owner}"}  ${optionList})`, toQuery)
   }
 
   eventListByAddress(address: string, options?: QueryProps<BaseEvent>): GraphQuery {
@@ -51,27 +53,32 @@ class SquidClient implements AbstractClient<SquidCollection, SquidNFT> {
 
   nftListByOwner(owner: string, options?: QueryProps<SquidNFT>): GraphQuery {
     const toQuery = getFields(options?.fields)
-    return build(`nfts: nftEntities(where: {currentOwner_eq: "${owner}"})`, toQuery)
+    const optionList = optionToQuery(options, true)
+    return build(`nfts: nftEntities(where: {currentOwner_eq: "${owner}"} ${optionList})`, toQuery)
   }
 
   nftListByIssuer(issuer: string, options?: QueryProps<SquidNFT>): GraphQuery {
     const toQuery = getFields(options?.fields)
-    return build(`nfts: nftEntities(where: {issuer_eq: "${issuer}"})`, toQuery)
+    const optionList = optionToQuery(options, true)
+    return build(`nfts: nftEntities(where: {issuer_eq: "${issuer}"} ${optionList})`, toQuery)
   }
 
   nftListCollectedBy(address: string, options?: QueryProps<SquidNFT>): GraphQuery {
     const toQuery = getFields(options?.fields)
-    return build(`nfts: nftEntities(where: {currentOwner_eq: "${address}", issuer_not_eq: "${address}"})`, toQuery)
+    const optionList = optionToQuery(options, true)
+    return build(`nfts: nftEntities(where: {currentOwner_eq: "${address}", issuer_not_eq: "${address}"} ${optionList})`, toQuery)
   }
 
   nftListSoldBy(address: string, options?: QueryProps<SquidNFT>): GraphQuery {
     const toQuery = getFields(options?.fields)
-    return build(`nfts: nftEntities(where: {currentOwner_not_eq: "${address}", issuer_eq: "${address}"})`, toQuery)
+    const optionList = optionToQuery(options, true)
+    return build(`nfts: nftEntities(where: {currentOwner_not_eq: "${address}", issuer_eq: "${address}"} ${optionList})`, toQuery)
   }
 
   nftListByCollectionId(id: string, options?: QueryProps<SquidNFT>): GraphQuery {
     const toQuery = getFields(options?.fields)
-    return build(`nfts: nftEntities(where: {collection: {id_eq: "${id}"}})`, toQuery)
+    const optionList = optionToQuery(options, true)
+    return build(`nfts: nftEntities(where: {collection: {id_eq: "${id}"}} ${optionList})`, toQuery)
   }
 
   nftListForSale(options?: QueryProps<SquidNFT>): GraphQuery {

--- a/src/clients/defaults.ts
+++ b/src/clients/defaults.ts
@@ -1,6 +1,6 @@
-import { ObjProp, Fields, QueryOptions, BaseEvent } from '../types'
+import { ObjProp, Fields, QueryOptions, BaseEvent, AbstractBase } from '../types'
 
-export const defaultField = ['id', 'metadata', 'currentOwner', 'issuer']
+export const defaultField: ObjProp<AbstractBase> = ['id', 'createdAt', 'name', 'metadata', 'currentOwner', 'issuer']
 export const defaultEventField: ObjProp<BaseEvent> = ['id', 'interaction', 'timestamp', 'caller', 'meta']
 export const DEFAULT_LIMIT = 20
 // todo: add default orderBy

--- a/src/clients/defaults.ts
+++ b/src/clients/defaults.ts
@@ -2,7 +2,7 @@ import { ObjProp, Fields, QueryOptions, BaseEvent, AbstractBase } from '../types
 
 export const defaultField: ObjProp<AbstractBase> = ['id', 'createdAt', 'name', 'metadata', 'currentOwner', 'issuer']
 export const defaultEventField: ObjProp<BaseEvent> = ['id', 'interaction', 'timestamp', 'caller', 'meta']
-export const DEFAULT_LIMIT = 20
+export const DEFAULT_LIMIT = 100
 // todo: add default orderBy
 export const defaultQueryOptions: QueryOptions = {
   limit: DEFAULT_LIMIT

--- a/src/rest/ask.ts
+++ b/src/rest/ask.ts
@@ -2,16 +2,17 @@
 // TODO: fn returns { data: T } but should return T
 // unwrap data should be done in the caller
 import { $fetch } from 'ohmyfetch'
+import { QueryProps } from '../types'
 import { pathToRequest } from './path'
 import { GraphLike } from './types'
 import { getOptions } from './utils'
 
 const GRAPHQL_PATH = '/graphql'
 
-function askFor<T>(path: string): Promise<GraphLike<T>> {
-  const request = pathToRequest(path)
-  const options = getOptions(request)
-  return $fetch<GraphLike<T>>(GRAPHQL_PATH, options)
+function askFor<T>(path: string, options?: QueryProps<T>): Promise<GraphLike<T>> {
+  const request = pathToRequest(path, options)
+  const opts = getOptions(request)
+  return $fetch<GraphLike<T>>(GRAPHQL_PATH, opts)
 }
 
 export { askFor as ask }

--- a/src/rest/path.ts
+++ b/src/rest/path.ts
@@ -1,6 +1,6 @@
 import { $URL, withoutLeadingSlash } from 'ufo'
 import getClient from '../clients/factory'
-import { GraphQuery } from '../types'
+import { GraphQuery, QueryProps } from '../types'
 import { getUrl } from './indexers'
 import { ClientCall, GraphRequest, Prefix } from './types'
 
@@ -33,7 +33,7 @@ const supportChain = (chain: string | undefined): boolean => {
 }
 
 const urlOf = (path: string): $URL => new $URL(path)
-const makeQuery = (call: string, id: string): GraphQuery => {
+const makeQuery = (call: string, id: string, options?: QueryProps<any>): GraphQuery => {
   const client = getClient()
   const method = getCall(call)
   const fn: any | undefined = client[method]
@@ -41,12 +41,12 @@ const makeQuery = (call: string, id: string): GraphQuery => {
     throw new ReferenceError(`[UNIQUERY::REST] Unable to make call: ${call}`)
   }
 
-  return fn(id)
+  return fn(id, options)
 }
 
 // /bsx/nft/:id
 // TODO: should return GraphRequest
-export function pathToRequest(path: string): GraphRequest {
+export function pathToRequest(path: string, options?: QueryProps<any>): GraphRequest {
   const { pathname } = urlOf(path) // query: options
   const [chain, call, id] = parsePath(pathname)
   if (!hasCall(call) || !supportChain(chain)) {
@@ -54,7 +54,7 @@ export function pathToRequest(path: string): GraphRequest {
   }
 
   const baseURL = getUrl(chain as Prefix)
-  const graphQuery = makeQuery(call, id)
+  const graphQuery = makeQuery(call, id, options)
 
   return { baseURL, query: graphQuery, path }
   // const [chain, call, param] = path.split('/').filter(Boolean)

--- a/src/smartQuery.ts
+++ b/src/smartQuery.ts
@@ -1,0 +1,11 @@
+import { optionToQuery } from './clients/defaults'
+import build from './queryBuilder'
+import { FieldList, GraphQuery, KeyValue, QueryOptions } from './types'
+
+type GraphEntity = `${string}: ${string}` | string
+type RichOptions = QueryOptions & { fields?: FieldList, variables?: KeyValue }
+
+export function buildSmart(entity: GraphEntity, where: Record<string, string>, { fields, variables, ...options }: RichOptions): GraphQuery {
+  const optionList = optionToQuery(options, true)
+  return build(`${entity}(where: ${JSON.stringify(where)} ${optionList})`, fields, variables)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,16 @@ export type QueryProps<T> = QueryOptions & {
   fields?: ObjProp<T>
 }
 
+type Base = {
+  blockNumber: bigint
+  createdAt: Date
+  currentOwner: string
+  id: string
+  issuer: string
+  metadata: string
+  name: string
+}
+
 type MetadataEntity = {
   id: string
   name: string
@@ -34,17 +44,11 @@ type MetadataEntity = {
   type: string
 }
 
-export type BaseCollection = {
-  version: string
-  name: string
+export type BaseCollection = Base & {
   max: number
-  issuer: string
-  symbol: string
-  id: string
   metadata: string
-  currentOwner: string
-  blockNumber: bigint
-  createdAt: Date
+  symbol: string
+  version: string
 }
 
 export type SquidCollection = BaseCollection & {
@@ -53,20 +57,13 @@ export type SquidCollection = BaseCollection & {
   meta: MetadataEntity
 }
 
-export type BaseNFT = {
-  name: string
-  instance: string
-  transferable: number
-  collection: SquidCollection
-  issuer: string
-  sn: string
-  id: string
-  metadata: string
-  currentOwner: string
-  price: bigint
+export type BaseNFT = Base & {
   burned: Boolean
-  blockNumber: bigint
-  createdAt: Date
+  collection: SquidCollection
+  instance: string
+  price: bigint
+  sn: string
+  transferable: number
   updatedAt: Date
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type QueryProps<T> = QueryOptions & {
   fields?: ObjProp<T>
 }
 
-type Base = {
+export type AbstractBase = {
   blockNumber: bigint
   createdAt: Date
   currentOwner: string
@@ -44,7 +44,7 @@ type MetadataEntity = {
   type: string
 }
 
-export type BaseCollection = Base & {
+export type BaseCollection = AbstractBase & {
   max: number
   metadata: string
   symbol: string
@@ -57,7 +57,7 @@ export type SquidCollection = BaseCollection & {
   meta: MetadataEntity
 }
 
-export type BaseNFT = Base & {
+export type BaseNFT = AbstractBase & {
   burned: Boolean
   collection: SquidCollection
   instance: string


### PR DESCRIPTION
- :label: Base
- :label: AbstractBase
- :technologist: default fields are longer
- :zap: @yangwao said that
- :bug: Squid client did not support options
- :zap: accept options
- :tada: REST has options
- :construction: nicer way to build queries
